### PR TITLE
Remove duplicated authors

### DIFF
--- a/LubimyCzytacFetch.js
+++ b/LubimyCzytacFetch.js
@@ -74,7 +74,11 @@ const fetchBook = async (bookUrl) => {
     title = $('h1[itemprop="name"]').text();
   }
 
-  const author = $('.author-info-container a[itemprop="name"]').map((_, el) => $(el).text()).get().join(' ,');
+  let authorsList = $('.author-info-container a[itemprop="name"]').map((_, el) => $(el).text()).get();
+  if (authorsList.length > 2) {
+    authorsList = authorsList.slice(2)
+  }
+  const author =  authorsList.join(', ')
   const bookDetails = fetchBookDetails($);
   return {
     title,


### PR DESCRIPTION
It fixes a bug of duplicating authors, which occurs if there are more than two authors of the book.

For example:

http://lubimyczytac.pl/ksiazka/185218/html5-i-css3-zaawansowane-wzorce-projektowe
```
{ 
       title: 'HTML5 i CSS3. Zaawansowane wzorce projektowe',
       author: 'Michael Bowers, Dionysios Synodinos, Michael Bowers, Dionysios Synodinos, Victor Sumner',
       isbn: '9788324644711',
       publishingDate: undefined
}
```